### PR TITLE
updated frame management + clean frames buttons and modals

### DIFF
--- a/client/src/components/global/AddFrameModal.tsx
+++ b/client/src/components/global/AddFrameModal.tsx
@@ -5,10 +5,17 @@ import { IconCheck } from "@tabler/icons-react";
 import { useForm } from "@mantine/form";
 import { IconPlus } from "@tabler/icons-react";
 import { useState } from "react";
+import frames from '../../data/frames.json';
 
 interface AddFrameModalProps {
   opened: boolean;
   onClose: () => void;
+}
+
+interface FormValues {
+  frameName: string;
+  description: string;
+  [key: string]: string;
 }
 
 const AddFrameModal: React.FC<AddFrameModalProps> = ({ opened, onClose }) => {
@@ -20,12 +27,26 @@ const AddFrameModal: React.FC<AddFrameModalProps> = ({ opened, onClose }) => {
 
   const form = useForm({
     initialValues: {
-      email: '',
-      termsOfService: false,
+      frameName: '',
+      description: '',
+      role0: '',
     },
 
     validate: {
-      email: (value) => (/^\S+@\S+$/.test(value) ? null : 'Invalid email'),
+      frameName: (value) => {
+        // Return `null` if it's valid, or an error message if it's invalid
+        if (value.trim() === "") {
+          return "Map name is required";
+        }
+        return null;
+      },
+      description: (value) => {
+        // Return `null` if it's valid, or an error message if it's invalid
+        if (value.trim() === "") {
+          return "Description is required";
+        }
+        return null;
+      },
     },
   });
 
@@ -38,65 +59,93 @@ const AddFrameModal: React.FC<AddFrameModalProps> = ({ opened, onClose }) => {
     })
   }
 
+  const handleFormSubmit = () => {
+    // form.submit();
+    console.log("HANDLING FORM SUBMIT")
+    console.log(form.values);
+
+    const maxId = Math.max(...frames.map(frame => frame.id));
+
+    // Create a new object with the id being 1 more than the maxId
+    const newFrame = {
+      id: maxId + 1,
+      name: (form.values as FormValues).frameName,
+      description: (form.values as FormValues).description,
+      roles: inputs.map((input, index) => ({
+        name: (form.values as FormValues)[`role${index}`],
+        values: []
+      }))
+    };
+
+    console.log(newFrame, "NEW FRAME");
+
+    handleConfirm();
+  };
+
   return (
     <>
-      <Modal id="delete-modal" opened={opened} onClose={onClose} title="Add Frame" centered size="xl">
-        <SimpleGrid cols={2} spacing="xl">
-          <Box>
-            <TextInput
-              label="Frame Name"
-              description="Enter a name to describe your frame"
-              placeholder="Buying"
-              style={{ width: "100%", marginBottom: "20px" }}
-              data-autofocus
-              withAsterisk
-            // {...form.getInputProps("mapName")}
-            />
-            <Textarea
-              label="Frame Description"
-              description="Enter a description to describe your frame"
-              placeholder="Describes the act of buying something"
-              style={{ width: "100%", marginBottom: "20px" }}
-              variant="filled"
-              data-autofocus
-              withAsterisk
-            />
-          </Box>
-          <Box>
-            <TextInput
-              label="Roles Name"
-              description="Enter roles that are associated with this frame"
-              placeholder="Seller"
-              style={{ marginBottom: "10px"}}
-              data-autofocus
-              withAsterisk
-            // {...form.getInputProps("mapName")}
-            />
-            {inputs.map((input, index) => (
+      <Modal id="add-frame-modal" opened={opened} onClose={onClose} title="Add Frame" centered size="xl">
+        <form onSubmit={form.onSubmit((values) => handleFormSubmit())}>
+          <SimpleGrid cols={2} spacing="xl">
+            <Box>
               <TextInput
-                style={{ marginBottom: "10px"}}
-                key={index}
-                placeholder={input.placeholder}
-                rightSection={<CloseButton onClick={() => setInputs(inputs => inputs.filter((_, i) => i !== index))} />}
+                label="Frame Name"
+                description="Enter a name to describe your frame"
+                placeholder="Buying"
+                style={{ width: "100%", marginBottom: "20px" }}
+                data-autofocus
+                withAsterisk
+                {...form.getInputProps("frameName")}
               />
-            ))}
-            <ActionIcon variant="subtle" aria-label="Add role" 
+              <Textarea
+                label="Frame Description"
+                description="Enter a description to describe your frame"
+                placeholder="Describes the act of buying something"
+                style={{ width: "100%", marginBottom: "20px" }}
+                variant="filled"
+                data-autofocus
+                withAsterisk
+                {...form.getInputProps("description")}
+              />
+            </Box>
+            <Box>
+              <TextInput
+                label="Roles Name"
+                description="Enter roles that are associated with this frame"
+                placeholder="Seller"
+                style={{ marginBottom: "10px" }}
+                data-autofocus
+                withAsterisk
+                {...form.getInputProps("role0")}
+              />
+              {inputs.map((input, index) => (
+                <TextInput
+                  style={{ marginBottom: "10px" }}
+                  key={index}
+                  placeholder={input.placeholder}
+                  defaultValue={""}
+                  rightSection={<CloseButton onClick={() => setInputs(inputs => inputs.filter((_, i) => i !== index))} />}
+                  {...form.getInputProps(`role${index + 1}`)}
+                />
+              ))}
+              <ActionIcon variant="subtle" aria-label="Add role"
+                style={{ marginLeft: "auto" }}
+                onClick={handleAddInput}>
+                <IconPlus style={{ width: '70%', height: '70%' }} stroke={1.5} />
+              </ActionIcon>
+
+            </Box>
+          </SimpleGrid>
+
+          <Group justify="space-between">
+            <Button variant="filled"
+              type="submit"
               style={{ marginLeft: "auto" }}
-              onClick={handleAddInput}>
-              <IconPlus style={{ width: '70%', height: '70%' }} stroke={1.5} />
-            </ActionIcon>
-
-          </Box>
-        </SimpleGrid>
-
-        <Group justify="space-between">
-          <Button variant="light" onClick={onClose} id="delete-modal-cancel-button">
-            Cancel
-          </Button>
-          <Button variant="filled" onClick={handleConfirm} id="delete-modal-confirm-button">
-            Confirm
-          </Button>
-        </Group>
+              id="add-frame-modal-confirm-button">
+              Confirm
+            </Button>
+          </Group>
+        </form>
       </Modal>
     </>
   );

--- a/client/src/components/global/AddRoleModal.tsx
+++ b/client/src/components/global/AddRoleModal.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Modal, Button, Group, TextInput, Textarea, SimpleGrid, Box, ActionIcon, CloseButton } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { IconCheck } from "@tabler/icons-react";
+import { useForm } from "@mantine/form";
+import { IconPlus } from "@tabler/icons-react";
+import { useState } from "react";
+
+interface AddRoleModalProps {
+  opened: boolean;
+  onClose: () => void;
+}
+
+const AddRoleModal: React.FC<AddRoleModalProps> = ({ opened, onClose }) => {
+  const [inputs, setInputs] = useState([{ placeholder: 'Input placeholder' }]);
+
+  const handleAddInput = () => {
+    setInputs(inputs => [...inputs, { placeholder: 'Input placeholder'}]);
+  };
+
+  const form = useForm({});
+
+  const handleConfirm = () => {
+    onClose();
+    notifications.show({
+      icon: <IconCheck />,
+      title: 'Your roles has been add!',
+      message: 'Wooohoo! :)',
+    })
+  }
+
+  const handleFormSubmit = () => {
+    // form.submit();
+    console.log("HANDLING FORM SUBMIT")
+    console.log(form.values);
+    onClose();
+  };
+
+  return (
+    <>
+      <Modal id="add-role-modal" opened={opened} onClose={onClose} title="Add Role" centered size="xl">
+        <form onSubmit={form.onSubmit((values) => handleFormSubmit())}>
+          <Box>
+            <TextInput
+              label="Roles Name"
+              description="Enter roles that are associated with this frame"
+              placeholder="Seller"
+              defaultValue={""}
+              style={{ marginBottom: "10px" }}
+              data-autofocus
+              withAsterisk
+              {...form.getInputProps("role0")}
+            />
+            {inputs.map((input, index) => (
+              <TextInput
+                style={{ marginBottom: "10px" }}
+                key={index}
+                defaultValue={""}
+                placeholder={input.placeholder}
+                rightSection={<CloseButton onClick={() => setInputs(inputs => inputs.filter((_, i) => i !== index))} />}
+                {...form.getInputProps(`role${index + 1}`)}
+              />
+            ))}
+            <ActionIcon variant="subtle" aria-label="Add role"
+              style={{ marginLeft: "auto" }}
+              onClick={handleAddInput}>
+              <IconPlus style={{ width: '70%', height: '70%' }} stroke={1.5} />
+            </ActionIcon>
+          </Box>
+          <Group justify="space-between">
+            <Button variant="filled"
+              type="submit"
+              style={{ marginLeft: "auto" }}
+              id="add-role-modal-confirm-button">
+              Add roles
+            </Button>
+          </Group>
+        </form>
+      </Modal >
+    </>
+  );
+}
+
+export default AddRoleModal;

--- a/client/src/components/pages/CleanFrame/CleanFrame.tsx
+++ b/client/src/components/pages/CleanFrame/CleanFrame.tsx
@@ -2,44 +2,26 @@ import { FrameTable } from "./FrameTable"
 import { Button, Breadcrumbs, Anchor, Group, Stack } from "@mantine/core"
 import { notifications } from '@mantine/notifications';
 import { useParams } from "react-router-dom";
-import { useState, useEffect} from "react";
+import { useState, useEffect } from "react";
 import { RolesTable } from "./RolesTable";
+import { Frame } from '../../../utils/Hooks';
 
 const CleanFrame = () => {
     // This is the hook that allows us to navigate to different pages
     const { selectedFrame } = useParams();
     const [table, setTable] = useState("frames");
+    const [selectedRecords, setSelectedRecords] = useState<Frame[]>([]);
 
     useEffect(() => {
-        if(selectedFrame) {
+        if (selectedFrame) {
             setTable("roles");
         }
     }, [selectedFrame]);
 
-    const items = [
-        { title: 'Frames', href: '/cleanFrame' },
-        { title: `${selectedFrame}`, href: '' },
-        // { title: 'use-id', href: '#' },
-    ]
-    .filter(item => item.title !== 'undefined')
-    .map((item, index) => (
-        <Anchor href={item.href} key={index}>
-            {item.title}
-        </Anchor>
-    ));
-
-    function ShowNotification(clickedButton: string) {
-        notifications.show({
-            title: `${clickedButton} Button Clicked`,
-            message: `You clicked on me!`,
-            withBorder: true,
-        })
-    }
-    
     const renderTable = () => {
-        if(table === "frames") {
+        if (table === "frames") {
             return <FrameTable />
-        } else if(table === "roles") {
+        } else if (table === "roles") {
             return <RolesTable />
         }
     }
@@ -48,16 +30,6 @@ const CleanFrame = () => {
         <>
             <h1>Clean Frame</h1>
             <Stack>
-                <Group>
-                    <Breadcrumbs>{items}</Breadcrumbs>
-                    <Button
-                        variant="outline" color="red"
-                        onClick={() => ShowNotification("Delete")}
-                        style={{ marginLeft: "auto" }}
-                    >Delete
-                    </Button>
-                    <Button variant="outline" color="orange" onClick={() => ShowNotification("Edit")}>Edit</Button>
-                </Group>
                 {renderTable()}
             </Stack>
 

--- a/client/src/components/pages/CleanFrame/FrameTable.tsx
+++ b/client/src/components/pages/CleanFrame/FrameTable.tsx
@@ -3,9 +3,11 @@
 import { DataTable, DataTableColumn } from 'mantine-datatable';
 import { notifications } from '@mantine/notifications';
 import { useState, useEffect } from 'react';
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Frame } from '../../../utils/Hooks';
 import frames from '../../../data/frames.json';
+import { Button, Group, Breadcrumbs, Anchor } from '@mantine/core';
+import { ShowNotification } from '../../../utils/Global';
 
 const columns: DataTableColumn<Frame>[] = [
     { accessor: 'name', width: '100%' },
@@ -16,7 +18,7 @@ const PAGE_SIZE = 10;
 export function FrameTable() {
     // This is the hook that allows us to navigate to different pages
     const navigate = useNavigate();
-
+    const { selectedFrame } = useParams();
     const [page, setPage] = useState(1);
     const [records, setRecords] = useState(frames.slice(0, PAGE_SIZE));
     const [selectedRecords, setSelectedRecords] = useState<Frame[]>([]);
@@ -38,8 +40,36 @@ export function FrameTable() {
         navigate(`/cleanFrame/${record.name}`);
     };
 
+    const items = [
+        { title: 'Frames', href: '/cleanFrame' },
+        { title: `${selectedFrame}`, href: '' },
+    ]
+        .filter(item => item.title !== 'undefined')
+        .map((item, index) => (
+            <Anchor href={item.href} key={index}>
+                {item.title}
+            </Anchor>
+        ));
+
+
     return (
         <>
+            <Group>
+                <Breadcrumbs>{items}</Breadcrumbs>
+                <Button
+                    variant="outline" color="red"
+                    style={{ marginLeft: "auto" }}
+                    disabled={selectedRecords.length === 0}
+                    onClick={() => ShowNotification("Delete")}
+                >Delete
+                </Button>
+                <Button variant="outline"
+                    onClick={() => ShowNotification("Edit")}
+                    disabled={selectedRecords.length !== 1}
+                    color="orange">
+                    Edit
+                </Button>
+            </Group>
             <DataTable
                 striped
                 minHeight={180}

--- a/client/src/components/pages/CleanFrame/RolesTable.tsx
+++ b/client/src/components/pages/CleanFrame/RolesTable.tsx
@@ -2,10 +2,12 @@
 
 import { DataTable, DataTableColumn } from 'mantine-datatable';
 import { notifications } from '@mantine/notifications';
-import { useState} from 'react';
+import { useState } from 'react';
 import { useParams } from "react-router-dom";
 import { Frame } from '../../../utils/Hooks';
 import frames from '../../../data/frames.json';
+import { Button, Group, Breadcrumbs, Anchor } from '@mantine/core';
+import { ShowNotification } from '../../../utils/Global';
 
 const columns: DataTableColumn<Frame>[] = [
     { accessor: 'name', width: '100%' },
@@ -13,8 +15,8 @@ const columns: DataTableColumn<Frame>[] = [
 
 export function RolesTable() {
     // This is the hook that allows us to navigate to different pages
-    const [selectedRecords, setSelectedRecords] = useState<Frame[]>([]);
     const { selectedFrame } = useParams();
+    const [selectedRecords, setSelectedRecords] = useState<Frame[]>([]);
     const frame = frames.find(frame => frame.name === selectedFrame);
     console.log(frame);
     const roles = frame?.roles;
@@ -29,8 +31,42 @@ export function RolesTable() {
         });
     };
 
+    const items = [
+        { title: 'Frames', href: '/cleanFrame' },
+        { title: `${selectedFrame}`, href: '' },
+    ]
+        .filter(item => item.title !== 'undefined')
+        .map((item, index) => (
+            <Anchor href={item.href} key={index}>
+                {item.title}
+            </Anchor>
+        ));
+
     return (
         <>
+            {/* Display frame add */}
+            {selectedFrame &&
+                <Group>
+                    <Breadcrumbs>{items}</Breadcrumbs>
+                    <Button variant="outline" color="red"
+                        onClick={() => ShowNotification("Delete")}
+                        disabled={selectedRecords.length === 0}
+                        style={{ marginLeft: "auto" }}>
+                        Delete
+                    </Button>
+                    <Button variant="outline" color="orange"
+                        disabled={selectedRecords.length === 0}
+                        onClick={() => ShowNotification("Deactivate")}>
+                        Deactivate
+                    </Button>
+                    <Button variant="outline"
+                        color="green"
+                        disabled={selectedRecords.length === 0}
+                        onClick={() => ShowNotification("Activate")}>
+                        Activate
+                    </Button>
+                </Group>
+            }
             <DataTable
                 striped
                 highlightOnHover
@@ -38,6 +74,7 @@ export function RolesTable() {
                 withColumnBorders
                 records={roles}
                 columns={columns}
+                idAccessor={({ name, id }) => `${name}:${id}`}
                 selectedRecords={selectedRecords}
                 onSelectedRecordsChange={setSelectedRecords}
                 onRowClick={({ record, index }) => handleRowClick(record, index)}

--- a/client/src/components/pages/FrameManagement/FrameManagement.tsx
+++ b/client/src/components/pages/FrameManagement/FrameManagement.tsx
@@ -1,46 +1,21 @@
-import { Button, Breadcrumbs, Anchor, Group, Stack } from "@mantine/core"
+import { Button, Breadcrumbs, Anchor, Group, Stack, Title } from "@mantine/core"
 import { useDisclosure } from "@mantine/hooks";
 // import { notifications } from '@mantine/notifications';
 import { useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { FrameTable } from "./FrameTable"
 import { RolesTable } from "./RolesTable";
-import DeleteFrameModal from "../../global/DeleteFrameModal";
-import AddFrameModal from "../../global/AddFrameModal";
-import EditFrameModal from "../../global/EditFrameModal";
 
 const ManageFrame = () => {
     // This is the hook that allows us to navigate to different pages
     const { selectedFrame } = useParams();
     const [table, setTable] = useState("frames");
-    const [addModalOpened, setAddModal] = useDisclosure(false);
-    const [editModalOpened, setEditModal] = useDisclosure(false);
-    const [deleteModalOpened, setDeleteModal] = useDisclosure(false);
 
     useEffect(() => {
         if (selectedFrame) {
             setTable("roles");
         }
     }, [selectedFrame]);
-
-    const items = [
-        { title: 'Frames', href: '/manageFrame' },
-        { title: `${selectedFrame}`, href: '' },
-    ]
-        .filter(item => item.title !== 'undefined')
-        .map((item, index) => (
-            <Anchor href={item.href} key={index}>
-                {item.title}
-            </Anchor>
-        ));
-
-    // function ShowNotification(clickedButton: string) {
-    //     notifications.show({
-    //         title: `${clickedButton} Button Clicked`,
-    //         message: `You clicked on me!`,
-    //         withBorder: true,
-    //     })
-    // }
 
     const renderTable = () => {
         if (table === "frames") {
@@ -52,46 +27,8 @@ const ManageFrame = () => {
 
     return (
         <>
-            <h1>Frame Management</h1>
-            {/* Show delete modal when needed */}
-            {addModalOpened && (
-                <AddFrameModal
-                    opened={addModalOpened}
-                    onClose={setAddModal.close}
-                ></AddFrameModal>
-            )}
-            {/* Show edit modal when needed */}
-            {editModalOpened && (
-                <EditFrameModal
-                    opened={editModalOpened}
-                    onClose={setEditModal.close}
-                ></EditFrameModal>
-            )}
-            {/* Show delete modal when needed */}
-            {deleteModalOpened && (
-                <DeleteFrameModal
-                    opened={deleteModalOpened}
-                    onClose={setDeleteModal.close}
-                ></DeleteFrameModal>
-            )}
+            <Title order={2} c="blue">Frame Management</Title>
             <Stack>
-                <Group>
-                    <Breadcrumbs>{items}</Breadcrumbs>
-                    <Button
-                        variant="outline" color="red"
-                        style={{ marginLeft: "auto" }}
-                        onClick={setDeleteModal.open}>
-                        Delete
-                    </Button>
-                    <Button variant="outline" color="orange"
-                        onClick={() => setEditModal.open}>
-                        Edit
-                    </Button>
-                    <Button variant="outline" color="green"
-                        onClick={setAddModal.open}>
-                        Add
-                    </Button>
-                </Group>
                 {renderTable()}
             </Stack>
 

--- a/client/src/components/pages/FrameManagement/FrameTable.tsx
+++ b/client/src/components/pages/FrameManagement/FrameTable.tsx
@@ -3,24 +3,39 @@
 import { DataTable, DataTableColumn } from 'mantine-datatable';
 import { notifications } from '@mantine/notifications';
 import { useState, useEffect } from 'react';
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Frame } from '../../../utils/Hooks';
 import frames from '../../../data/frames.json';
+import { Button, Group, Breadcrumbs, Anchor } from '@mantine/core';
+import AddFrameModal from "../../global/AddFrameModal";
+import { useDisclosure } from "@mantine/hooks";
 
 const columns: DataTableColumn<Frame>[] = [
     { accessor: 'name', width: '25%' },
     { accessor: 'description', width: '75%' },
 ];
 
-const PAGE_SIZE = 15;
+const PAGE_SIZE = 100;
 
 export function FrameTable() {
     // This is the hook that allows us to navigate to different pages
     const navigate = useNavigate();
-
+    const { selectedFrame } = useParams();
     const [page, setPage] = useState(1);
+    // const [selectedRecords, setSelectedRecords] = useState<Frame[]>([]);
     const [records, setRecords] = useState(frames.slice(0, PAGE_SIZE));
-    const [selectedRecords, setSelectedRecords] = useState<Frame[]>([]);
+    const [addModalOpened, setAddModal] = useDisclosure(false);
+
+    const items = [
+        { title: 'Frames', href: '/manageFrame' },
+        { title: `${selectedFrame}`, href: '' },
+    ]
+        .filter(item => item.title !== 'undefined')
+        .map((item, index) => (
+            <Anchor href={item.href} key={index}>
+                {item.title}
+            </Anchor>
+        ));
 
     useEffect(() => {
         const from = (page - 1) * PAGE_SIZE;
@@ -39,24 +54,52 @@ export function FrameTable() {
         navigate(`/manageFrame/${record.name}`);
     };
 
+    const sortedRecords = [...records].sort((a, b) => a.name.localeCompare(b.name));
+
     return (
         <>
+            <Group >
+                <Breadcrumbs>{items}</Breadcrumbs>
+                {/* <Button
+                    variant="outline" color="red"
+                    style={{ marginLeft: "auto" }}
+                    >
+                    Delete
+                </Button>
+                <Button variant="outline" color="orange">
+                    Edit
+                </Button> */}
+                <Button variant="outline" color="green"
+                    style={{ marginLeft: "auto" }}
+                    onClick={setAddModal.open}>
+                    Add
+                </Button>
+            </Group>
+
             <DataTable
                 striped
                 minHeight={180}
                 highlightOnHover
                 withTableBorder
                 withColumnBorders
-                records={records}
+                records={sortedRecords}
                 columns={columns}
-                selectedRecords={selectedRecords}
-                onSelectedRecordsChange={setSelectedRecords}
+                // selectedRecords={selectedRecords}
+                // onSelectedRecordsChange={setSelectedRecords}
                 onRowClick={({ record, index }) => handleRowClick(record, index)}
                 totalRecords={frames.length}
                 recordsPerPage={PAGE_SIZE}
                 page={page}
                 onPageChange={(p) => setPage(p)}
             />
+
+            {/* Show delete modal when needed */}
+            {addModalOpened && (
+                <AddFrameModal
+                    opened={addModalOpened}
+                    onClose={setAddModal.close}
+                ></AddFrameModal>
+            )}
         </>
     );
 

--- a/client/src/components/pages/FrameManagement/RolesTable.tsx
+++ b/client/src/components/pages/FrameManagement/RolesTable.tsx
@@ -2,10 +2,15 @@
 
 import { DataTable, DataTableColumn } from 'mantine-datatable';
 import { notifications } from '@mantine/notifications';
-import { useState} from 'react';
+import { useState } from 'react';
 import { useParams } from "react-router-dom";
 import { Frame } from '../../../utils/Hooks';
 import frames from '../../../data/frames.json';
+import { Anchor, Button, Breadcrumbs, Group } from '@mantine/core';
+import DeleteFrameModal from "../../global/DeleteFrameModal";
+import EditFrameModal from "../../global/EditFrameModal";
+import AddRoleModal from '../../global/AddRoleModal';
+import { useDisclosure } from '@mantine/hooks';
 
 const columns: DataTableColumn<Frame>[] = [
     { title: 'Role', accessor: 'name', width: '100%' },
@@ -13,11 +18,26 @@ const columns: DataTableColumn<Frame>[] = [
 
 export function RolesTable() {
     // This is the hook that allows us to navigate to different pages
-    const [selectedRecords, setSelectedRecords] = useState<Frame[]>([]);
     const { selectedFrame } = useParams();
+    const [selectedRecords, setSelectedRecords] = useState<Frame[]>([]);
+    const [addModalOpened, setAddModal] = useDisclosure(false);
+    const [editModalOpened, setEditModal] = useDisclosure(false);
+    const [deleteModalOpened, setDeleteModal] = useDisclosure(false);
+
     const frame = frames.find(frame => frame.name === selectedFrame);
     console.log(frame);
     const roles = frame?.roles;
+
+    const items = [
+        { title: 'Frames', href: '/manageFrame' },
+        { title: `${selectedFrame}`, href: '' },
+    ]
+        .filter(item => item.title !== 'undefined')
+        .map((item, index) => (
+            <Anchor href={item.href} key={index}>
+                {item.title}
+            </Anchor>
+        ));
 
     // This function is called when the user clicks on a row
     // It will navigate to the page with the name of the frame
@@ -31,6 +51,25 @@ export function RolesTable() {
 
     return (
         <>
+            <Group >
+                <Breadcrumbs>{items}</Breadcrumbs>
+                <Button
+                    variant="outline" color="red"
+                    onClick={setDeleteModal.open}
+                    style={{ marginLeft: "auto" }}
+                    disabled={selectedRecords.length === 0}>
+                    Delete
+                </Button>
+                <Button variant="outline" color="orange"
+                    onClick={() => setEditModal.open}
+                    disabled={selectedRecords.length !== 1}>
+                    Edit
+                </Button>
+                <Button variant="outline" color="green"
+                    onClick={setAddModal.open}>
+                    Add
+                </Button>
+            </Group>
             <DataTable
                 striped
                 highlightOnHover
@@ -43,6 +82,28 @@ export function RolesTable() {
                 onSelectedRecordsChange={setSelectedRecords}
                 onRowClick={({ record, index }) => handleRowClick(record, index)}
             />
+
+            {/* Show delete modal when needed */}
+            {addModalOpened && (
+                <AddRoleModal
+                    opened={addModalOpened}
+                    onClose={setAddModal.close}
+                ></AddRoleModal>
+            )}
+            {/* Show edit modal when needed */}
+            {editModalOpened && (
+                <EditFrameModal
+                    opened={editModalOpened}
+                    onClose={setEditModal.close}
+                ></EditFrameModal>
+            )}
+            {/* Show delete modal when needed */}
+            {deleteModalOpened && (
+                <DeleteFrameModal
+                    opened={deleteModalOpened}
+                    onClose={setDeleteModal.close}
+                ></DeleteFrameModal>
+            )}
         </>
     );
 

--- a/client/src/components/pages/ParseFrame.tsx
+++ b/client/src/components/pages/ParseFrame.tsx
@@ -1,7 +1,27 @@
+import { Button, Box, Stack, Title, Textarea } from '@mantine/core';
+
 const ParseFrame = () => {
     return (
         <>
-        <h1>ParseFrame</h1>
+            <Stack style={{ width: "50%" }}>
+                <Title order={2} c="blue">Parse Frame</Title>
+                <Textarea
+                    variant="filled"
+                    size="md"
+                    required
+                    label="Enter your input sentences"
+                    description="Example: Mary buys a car for her daughter"
+                    placeholder="Start typing here"
+                />
+            </Stack>
+            <Button variant="filled" style={{ margin: "30px 0" }}>Find Frames</Button>
+
+            <Stack>
+                <Title order={2} c="blue">View Frames</Title>
+                <Box style={{border:"1px solid #868E96", borderRadius:"5px", width: "50%", height:"300px"}}>
+                
+                </Box>
+            </Stack>
         </>
     )
 }

--- a/client/src/utils/Global.tsx
+++ b/client/src/utils/Global.tsx
@@ -1,0 +1,9 @@
+import { notifications } from '@mantine/notifications';
+
+export function ShowNotification(clickedButton: string) {
+    notifications.show({
+        title: `${clickedButton} Button Clicked`,
+        message: `You clicked on me!`,
+        withBorder: true,
+    })
+}


### PR DESCRIPTION
Frame Management
- Updated table to include more frames per page
- Sorted frames alphabetically
- Removed delete + edit button on frame page
- Removed checkboxes
- Set up parsing logic to add new frame (view the console.log after submitting a new frame)
- Implemented foolproof design by disabling buttons when necessary
- Implemented Add Role Modal

<img width="1634" alt="image" src="https://github.com/sbu-kalm/KALM/assets/53535722/82549ce2-a14d-409d-87a6-00532f3751a5">
<img width="1634" alt="image" src="https://github.com/sbu-kalm/KALM/assets/53535722/1a2a3261-00c2-40ad-a74c-19a7b948875a">
<img width="1622" alt="image" src="https://github.com/sbu-kalm/KALM/assets/53535722/36caa0f4-129b-4de3-ac9f-8d67a39a6df6">
<img width="1635" alt="image" src="https://github.com/sbu-kalm/KALM/assets/53535722/9574c7da-71c1-43e1-bbf8-d099655ee641">

