### PR TITLE
fix: set weights_only to False in torch.load()

### DIFF
--- a/server/api/kalmfl/multistanza/models/common/pretrain.py
+++ b/server/api/kalmfl/multistanza/models/common/pretrain.py
@@ -50,7 +50,7 @@ class Pretrain:
     def load(self):
         if self.filename is not None and os.path.exists(self.filename):
             try:
-                data = torch.load(self.filename, lambda storage, loc: storage)
+                data = torch.load(self.filename, lambda storage, loc: storage, weights_only=False)
                 logger.debug("Loaded pretrain from {}".format(self.filename))
                 self._vocab, self._emb = PretrainedWordVocab.load_state_dict(data['vocab']), data['emb']
                 return


### PR DESCRIPTION
**Updates**
1. Fixed vector file loading error by setting weights_only to False in torch.load() (This is the default before PyTorch 2.6)

**Testing - Check off with x to verify you've completed the below**
- [x] Pulled recent changes from main branch
- [x] Tested via `npm start`

**How to review:**
```
git checkout main
git fetch
git checkout feature_branch
cd client
npm start
```

1. Go to browser & see something like below: 